### PR TITLE
Use --fullchain-file instead of --cert-file

### DIFF
--- a/app/gen-wildcard-cert
+++ b/app/gen-wildcard-cert
@@ -10,5 +10,5 @@ fi
   -d "$LETSENCRYPT_DOMAIN" \
   -d "*.$LETSENCRYPT_DOMAIN" \
   --accountemail "$LETSENCRYPT_EMAIL" \
-  --cert-file "/etc/nginx/certs/default.crt" \
+  --fullchain-file "/etc/nginx/certs/default.crt" \
   --key-file "/etc/nginx/certs/default.key"


### PR DESCRIPTION
While things are working as-is, you'll run into issues trying to `curl` from one of your domains. simp_le was using the full chain, and that was missed in https://github.com/mikew/docker-gen-letsencrypt/pull/1

If you are experiencing issues, you have a couple of options:

**Option 1:**

```sh
# move the existing fullchain to the existing cert
mv certs/yourdomain.com/fullchain.cer certs/default.crt
```

Next, edit `certs/yourdomain.com/yourdomain.com.conf`:

- set `Le_RealCertPath` to an empty string `''`
- set `Le_RealFullChainPath` to `/etc/nginx/certs/default.crt`

**Option 2**

Remove your certs and restart, letting them regenerate