### PR TITLE
chore: Update docker-gen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ENV DOCKER_GEN_VERSION=0.7.4
+ENV DOCKER_GEN_VERSION=0.9.2
 
 RUN apk add --update \
     bash \
@@ -10,7 +10,7 @@ RUN apk add --update \
     openssl \
     jq \
   && curl -L \
-    https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+    https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
     | tar -xzv -C /usr/local/bin \
   && mkdir -p /tmp/acme.sh \
   && curl -L \

--- a/app/entrypoint
+++ b/app/entrypoint
@@ -21,6 +21,5 @@ tail -f -n 0 /output/log &
 /app/letsencrypt-service &
 exec docker-gen \
     -watch \
-    -only-exposed \
     -notify /app/handle-new-spec \
     /app/spec.tmpl /output/spec

--- a/app/gen-nginx-conf
+++ b/app/gen-nginx-conf
@@ -41,6 +41,10 @@ map $http_upgrade $proxy_connection {
 
 nginx-server-conf () {
   for host in "${HOSTS[@]}"; do
+    if [ -z "${UPSTREAM[$host]}" ]; then
+      continue
+    fi
+
     echo "upstream $host {
       ${UPSTREAM[$host]}
     }"

--- a/app/spec.tmpl
+++ b/app/spec.tmpl
@@ -1,11 +1,60 @@
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
+
 {{ define "upstream" }}
-  {{ if .Address }}
-    {{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
-    {{ if and .Container.Node.ID .Address.HostPort }}
-add-upstream '{{ .Host }}' '{{ .Container.Node.Name }}/{{ .Container.Name }}' '{{ .Container.Node.Address.IP }}:{{ .Address.HostPort }}'
-    {{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
-    {{ else }}
-add-upstream '{{ .Host }}' '{{ .Container.Name }}' '{{ .Address.IP }}:{{ .Address.Port }}'
+  {{ $networks := .Networks }}
+  {{ $debug_all := .Debug }}
+  {{ $server_found := "false" }}
+  {{ $upstream := .Upstream }}
+
+  {{ range $container := .Containers }}
+    {{ $debug := (eq (coalesce $container.Env.DEBUG $debug_all "false") "true") }}
+
+    {{/* If only 1 port exposed, use that as a default, else 80 */}}
+    {{ $defaultPort := (when (eq (len $container.Addresses) 1) (first $container.Addresses) (dict "Port" "80")).Port }}
+    {{ $port := (coalesce $container.Env.VIRTUAL_PORT $defaultPort) }}
+
+    {{ $address := where $container.Addresses "Port" $port | first }}
+
+    {{ if $debug }}
+# exposed ports: {{ $container.Addresses }}
+# Default virtual port: {{ $defaultPort }}
+# VIRTUAL_PORT: {{ $container.Env.VIRTUAL_PORT }}
+      {{ if not $address }}
+# /!\ Virtual port not exposed
+      {{ end }}
+    {{ end }}
+
+    {{ range $knownNetwork := $networks }}
+      {{ range $containerNetwork := $container.Networks }}
+        {{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
+        {{/* if (ne $containerNetwork.Name "ingress") */}}
+          {{ if $address }}
+            {{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
+            {{ if and $container.Node.ID $address.HostPort }}
+              {{ $server_found = "true" }}
+add-upstream '{{ $upstream }}' '{{ $container.Node.Name }}/{{ $container.Name }}' '{{ $container.Node.Address.IP }}:{{ $address.HostPort }}'
+              {{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
+            {{ else if $containerNetwork }}
+              {{ $server_found = "true" }}
+add-upstream '{{ $upstream }}' '{{ $containerNetwork.Name }}/{{ $container.Name }}' '{{ $containerNetwork.IP }}:{{ $address.Port }}'
+            {{ end }}
+          {{ else if $containerNetwork }}
+            {{ if $containerNetwork.IP }}
+              {{ $server_found = "true" }}
+add-upstream '{{ $upstream }}' '{{ $containerNetwork.Name }}/{{ $container.Name }}' '{{ $containerNetwork.IP }}:{{ $port }}'
+            {{ else }}
+# /!\ No IP for this network!
+            {{ end }}
+          {{ end }}
+        {{ else }}
+# Cannot connect to network '{{ $containerNetwork.Name }}' of this container
+        {{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{/* nginx-proxy/nginx-proxy#1105 */}}
+    {{ if (eq $server_found "false") }}
+# /!\ Server not found
     {{ end }}
   {{ end }}
 {{ end }}
@@ -19,18 +68,6 @@ cors-origin '{{ $host }}' '{{ or (first (groupByKeys $containers "Env.CORS_ORIGI
 cors-methods '{{ $host }}' '{{ or (first (groupByKeys $containers "Env.CORS_METHODS")) "" }}'
 cors-headers '{{ $host }}' '{{ or (first (groupByKeys $containers "Env.CORS_HEADERS")) "" }}'
 
-{{ range $container := $containers }}
-  {{ $addrLen := len $container.Addresses }}
-  {{/* If only 1 port exposed, use that */}}
-  {{ if eq $addrLen 1 }}
-    {{ $address := index $container.Addresses 0 }}
-    {{ template "upstream" (dict "Host" $host "Container" $container "Address" $address) }}
-  {{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
-  {{ else }}
-    {{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
-    {{ $address := where $container.Addresses "Port" $port | first }}
-    {{ template "upstream" (dict "Host" $host "Container" $container "Address" $address) }}
-  {{ end }}
-{{ end }}
+{{ template "upstream" (dict "Upstream" $host "Containers" $containers "Networks" $CurrentContainer.Networks "Debug" "true") }}
 
 {{ end }}


### PR DESCRIPTION
I tried to make this as backwards compatible as possible, while also supporting 1:1 what nginx-proxy is doing for IP/port detection.

Part of what nginx-proxy does relies on the container that runs `docker-gen` be on the same type of network as your containers. If you're using `docker` commands, I'm not sure anything changes for you. But if you're using docker-compose, it does mean you need to worry about the network that this container is using:

```yml
services:
  docker-gen-letsencrypt:
    image: mikew/docker-gen-letsencrypt
    # Use either bridge networking or create a network
    network_mode: bridge
```